### PR TITLE
fix rounding problem

### DIFF
--- a/lib/stopwatch/timer.rb
+++ b/lib/stopwatch/timer.rb
@@ -45,7 +45,7 @@ module Stopwatch
     # timestamp to either nil (stop: true) or current time.
     def update(stop: false)
       if hours = runtime_hours and entry = self.time_entry
-        time_entry.update_column :hours, entry.hours + hours
+        time_entry.update_column :hours, entry.read_attribute(:hours) + hours
       end
       data[:started_at] = stop || !running? ? nil : Time.now.to_i
       save


### PR DESCRIPTION
Fixes the rounding problem. Since entry.hours is an getter with integrated round(2), its result should not be used for spent time calculation. Given the update function is called quite often (every 1-2 minutes), especially when the redmine issue is open in browser, it can disrupt the resulting overall logged time by up to 50%.